### PR TITLE
Updated solid mechanics executioner (refs #4475)

### DIFF
--- a/modules/solid_mechanics/src/executioners/AdaptiveTransient.C
+++ b/modules/solid_mechanics/src/executioners/AdaptiveTransient.C
@@ -191,7 +191,7 @@ AdaptiveTransient::init()
   _problem.initialSetup();
 
   Moose::setup_perf_log.push("Output Initial Condition","Setup");
-  _output_warehouse.outputStep(EXEC_INITIAL);
+  _problem.outputStep(EXEC_INITIAL);
   Moose::setup_perf_log.pop("Output Initial Condition","Setup");
 
   // If this is the first step
@@ -214,7 +214,7 @@ AdaptiveTransient::execute()
     if (lastSolveConverged())
       endStep();
   }
-  _output_warehouse.outputStep(EXEC_FINAL);
+  _problem.outputStep(EXEC_FINAL);
   postExecute();
 }
 
@@ -243,7 +243,7 @@ AdaptiveTransient::takeStep(Real input_dt)
   // Compute TimestepBegin Postprocessors
   _problem.computeUserObjects(EXEC_TIMESTEP_BEGIN);
 
-  _output_warehouse.outputStep(EXEC_TIMESTEP_BEGIN);
+  _problem.outputStep(EXEC_TIMESTEP_BEGIN);
 
   _console << "Solving time step ";
   {
@@ -327,7 +327,7 @@ AdaptiveTransient::endStep()
 {
   // if _synced_last_step is true, force the output no matter what
   if (_synced_last_step)
-    _output_warehouse.outputStep(EXEC_TIMESTEP_END);
+    _problem.outputStep(EXEC_TIMESTEP_END);
 
 #ifdef LIBMESH_ENABLE_AMR
   if (_problem.adaptivity().isOn())
@@ -465,7 +465,7 @@ AdaptiveTransient::computeDT()
   {
     if (dt <= _dtmin)
     { //Can't cut back any more
-      _output_warehouse.outputStep(EXEC_FAILED);
+      _problem.outputStep(EXEC_FAILED);
       mooseError("Solve failed and timestep already at dtmin, cannot continue!");
     }
 


### PR DESCRIPTION
I don't understand how modules compiled without these changes. The error was from the moose_unit compile.
